### PR TITLE
Fixes to remove warnings that popped up in compiling on my GCC 9.2.1 machine

### DIFF
--- a/jit.c
+++ b/jit.c
@@ -670,6 +670,7 @@ jit_init(struct cpu_driver* p_cpu_driver) {
   uint8_t* p_jit_trampolines;
   struct util_buffer* p_temp_buf;
   struct sigaction sa;
+  struct sigaction sa_prev;
   int ret;
 
   struct jit_struct* p_jit = (struct jit_struct*) p_cpu_driver;
@@ -768,13 +769,14 @@ jit_init(struct cpu_driver* p_cpu_driver) {
    * fast path doesn't need certain checks.
    */
   (void) memset(&sa, '\0', sizeof(sa));
+  (void) memset(&sa_prev, '\0', sizeof(sa_prev));
   sa.sa_sigaction = jit_handle_sigsegv;
   sa.sa_flags = (SA_SIGINFO | SA_NODEFER);
-  ret = sigaction(SIGSEGV, &sa, &sa);
+  ret = sigaction(SIGSEGV, &sa, &sa_prev);
   if (ret != 0) {
     errx(1, "sigaction failed");
   }
-  if ((sa.sa_sigaction != NULL) && (sa.sa_sigaction != jit_handle_sigsegv)) {
+  if ((sa_prev.sa_sigaction != NULL) && (sa_prev.sa_sigaction != jit_handle_sigsegv)) {
     errx(1, "conflicting SIGSEGV handler");
   }
 }

--- a/state.c
+++ b/state.c
@@ -12,6 +12,9 @@
 #include <stdio.h>
 #include <string.h>
 
+// TODO(mrg) this is a workaround to the places that pass an "int *" taken from the packed structure below
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+
 struct bem_v2x {
   uint8_t signature[8];
   uint8_t model;

--- a/via.c
+++ b/via.c
@@ -11,8 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const size_t k_via_tick_rate = 1000000; /* 1Mhz */
-
 enum {
   k_via_ORB =   0x0,
   k_via_ORA =   0x1,


### PR DESCRIPTION
...just FYI (I couldn't make this a draft PR as GitHub wouldn't let me). The jit.c and via.c changes are probably ok but the Waddress pragma is horrible and probably should be fixed another way.