### PR TITLE
Fix building with clang on Linux.

### DIFF
--- a/asm_x64_common.c
+++ b/asm_x64_common.c
@@ -6,6 +6,11 @@
 #include <limits.h>
 
 void
+asm_x64_unpatched_branch_target(void) {
+  asm __volatile__ ("int $3");
+}
+
+void
 asm_x64_copy(struct util_buffer* p_buf, void* p_start, void* p_end) {
   size_t size = (p_end - p_start);
   util_buffer_add_chunk(p_buf, p_start, size);

--- a/asm_x64_inturbo.S
+++ b/asm_x64_inturbo.S
@@ -35,7 +35,7 @@ asm_x64_inturbo_check_special_address:
   lea REG_SCRATCH2_32, [REG_SCRATCH1 + 0xFFFF]
 asm_x64_inturbo_check_special_address_lea_patch:
   bt REG_SCRATCH2_32, 16
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_inturbo_check_special_address_jb_patch:
 
 asm_x64_inturbo_check_special_address_END:
@@ -51,7 +51,7 @@ asm_x64_inturbo_check_countdown:
   lea REG_COUNTDOWN, [REG_COUNTDOWN - 1]
 asm_x64_inturbo_check_countdown_lea_patch:
   bt REG_COUNTDOWN, 63
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_inturbo_check_countdown_jb_patch:
 
 asm_x64_inturbo_check_countdown_END:
@@ -68,7 +68,7 @@ asm_x64_inturbo_check_countdown_with_page_crossing:
 asm_x64_inturbo_check_countdown_with_page_crossing_lea_patch:
   lea REG_COUNTDOWN, [REG_COUNTDOWN + REG_SCRATCH3]
   bt REG_COUNTDOWN, 63
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_inturbo_check_countdown_with_page_crossing_jb_patch:
 
 asm_x64_inturbo_check_countdown_with_page_crossing_END:
@@ -81,7 +81,7 @@ asm_x64_inturbo_check_countdown_with_page_crossing_END:
 asm_x64_inturbo_check_decimal:
 
   bt REG_6502_ID_F_64, 3
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_inturbo_check_decimal_jb_patch:
 
 asm_x64_inturbo_check_decimal_END:
@@ -98,7 +98,7 @@ asm_x64_inturbo_check_interrupt:
       DWORD PTR [REG_SCRATCH1 + K_STATE_6502_OFFSET_REG_IRQ_FIRE]
   lea REG_SCRATCH1_32, [REG_SCRATCH1 - 1]
   bt REG_SCRATCH1_32, 31
-  jae 0
+  jae asm_x64_unpatched_branch_target
 asm_x64_inturbo_check_interrupt_jae_patch:
 
 asm_x64_inturbo_check_interrupt_END:
@@ -145,7 +145,7 @@ asm_x64_inturbo_jump_opcode_END:
 .globl asm_x64_inturbo_enter_debug_END
 asm_x64_inturbo_enter_debug:
 
-  call 0
+  call asm_x64_unpatched_branch_target
 asm_x64_inturbo_enter_debug_END:
   ret
 
@@ -155,7 +155,7 @@ asm_x64_inturbo_enter_debug_END:
 .globl asm_x64_inturbo_jump_call_interp_jmp_patch
 asm_x64_inturbo_jump_call_interp:
 
-  jmp 0
+  jmp asm_x64_unpatched_branch_target
 asm_x64_inturbo_jump_call_interp_jmp_patch:
 
 asm_x64_inturbo_jump_call_interp_END:
@@ -338,7 +338,7 @@ asm_x64_inturbo_mode_idx:
   movzx REG_SCRATCH1_32, WORD PTR [REG_SCRATCH1 + K_BBC_MEM_READ_FULL_ADDR]
   # Handle special case of 0xFF via the interpreter.
   bt REG_SCRATCH2_32, 8
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_inturbo_mode_idx_jump_patch:
 
 asm_x64_inturbo_mode_idx_END:
@@ -359,7 +359,7 @@ asm_x64_inturbo_mode_idy:
 
   # Handle special case of 0xFF via the interpreter.
   bt REG_SCRATCH2_32, 8
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_inturbo_mode_idy_jump_patch:
 
 asm_x64_inturbo_mode_idy_END:
@@ -421,7 +421,7 @@ asm_x64_instruction_Bxx_interp_accurate:
   lea REG_COUNTDOWN, [REG_COUNTDOWN - 2]
   lea REG_COUNTDOWN, [REG_COUNTDOWN + REG_SCRATCH2]
   bt REG_COUNTDOWN, 63
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_instruction_Bxx_interp_accurate_jb_patch:
 
   movzx REG_SCRATCH3_32, BYTE PTR [REG_6502_PC + REG_SCRATCH1]
@@ -581,7 +581,7 @@ asm_x64_instruction_BCC_interp_END:
 asm_x64_instruction_BCC_interp_accurate:
 
   bt REG_6502_CF_64, 0
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_instruction_BCC_interp_accurate_jump_patch:
 
 asm_x64_instruction_BCC_interp_accurate_END:
@@ -609,7 +609,7 @@ asm_x64_instruction_BCS_interp_END:
 asm_x64_instruction_BCS_interp_accurate:
 
   bt REG_6502_CF_64, 0
-  jae 0
+  jae asm_x64_unpatched_branch_target
 asm_x64_instruction_BCS_interp_accurate_jump_patch:
 
 asm_x64_instruction_BCS_interp_accurate_END:
@@ -635,7 +635,7 @@ asm_x64_instruction_BEQ_interp_END:
 .globl asm_x64_instruction_BEQ_interp_accurate_jump_patch
 asm_x64_instruction_BEQ_interp_accurate:
 
-  jne 0
+  jne asm_x64_unpatched_branch_target
 asm_x64_instruction_BEQ_interp_accurate_jump_patch:
 
 asm_x64_instruction_BEQ_interp_accurate_END:
@@ -671,7 +671,7 @@ asm_x64_instruction_BMI_interp_END:
 .globl asm_x64_instruction_BMI_interp_accurate_jump_patch
 asm_x64_instruction_BMI_interp_accurate:
 
-  jns 0
+  jns asm_x64_unpatched_branch_target
 asm_x64_instruction_BMI_interp_accurate_jump_patch:
 
 asm_x64_instruction_BMI_interp_accurate_END:
@@ -697,7 +697,7 @@ asm_x64_instruction_BNE_interp_END:
 .globl asm_x64_instruction_BNE_interp_accurate_jump_patch
 asm_x64_instruction_BNE_interp_accurate:
 
-  je 0
+  je asm_x64_unpatched_branch_target
 asm_x64_instruction_BNE_interp_accurate_jump_patch:
 
 asm_x64_instruction_BNE_interp_accurate_END:
@@ -723,7 +723,7 @@ asm_x64_instruction_BPL_interp_END:
 .globl asm_x64_instruction_BPL_interp_accurate_jump_patch
 asm_x64_instruction_BPL_interp_accurate:
 
-  js 0
+  js asm_x64_unpatched_branch_target
 asm_x64_instruction_BPL_interp_accurate_jump_patch:
 
 asm_x64_instruction_BPL_interp_accurate_END:
@@ -751,7 +751,7 @@ asm_x64_instruction_BVC_interp_END:
 asm_x64_instruction_BVC_interp_accurate:
 
   bt REG_6502_OF_64, 0
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_instruction_BVC_interp_accurate_jump_patch:
 
 asm_x64_instruction_BVC_interp_accurate_END:
@@ -779,7 +779,7 @@ asm_x64_instruction_BVS_interp_END:
 asm_x64_instruction_BVS_interp_accurate:
 
   bt REG_6502_OF_64, 0
-  jae 0
+  jae asm_x64_unpatched_branch_target
 asm_x64_instruction_BVS_interp_accurate_jump_patch:
 
 asm_x64_instruction_BVS_interp_accurate_END:

--- a/asm_x64_jit.S
+++ b/asm_x64_jit.S
@@ -114,7 +114,7 @@ asm_x64_jit_call_compile_trampoline_END:
 asm_x64_jit_jump_interp_trampoline:
   mov REG_6502_PC_32, 0x7fffffff
 asm_x64_jit_jump_interp_trampoline_pc_patch:
-  jmp 0
+  jmp asm_x64_unpatched_branch_target
 asm_x64_jit_jump_interp_trampoline_jump_patch:
 
 asm_x64_jit_jump_interp_trampoline_END:
@@ -129,7 +129,7 @@ asm_x64_jit_check_countdown:
   lea REG_COUNTDOWN, [REG_COUNTDOWN - 0x80000000]
 asm_x64_jit_check_countdown_count_patch:
   bt REG_COUNTDOWN, 63
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_jit_check_countdown_jump_patch:
 
 asm_x64_jit_check_countdown_END:
@@ -144,7 +144,7 @@ asm_x64_jit_check_countdown_8bit:
   lea REG_COUNTDOWN, [REG_COUNTDOWN - 0x80]
 asm_x64_jit_check_countdown_8bit_count_patch:
   bt REG_COUNTDOWN, 63
-  jb 0
+  jb asm_x64_unpatched_branch_target
 asm_x64_jit_check_countdown_8bit_jump_patch:
 
 asm_x64_jit_check_countdown_8bit_END:
@@ -163,7 +163,7 @@ asm_x64_jit_call_debug_pc_patch:
   # So they must be saved.
   pushf
   push REG_SCRATCH1
-  call 0
+  call asm_x64_unpatched_branch_target
 asm_x64_jit_call_debug_call_patch:
   pop REG_SCRATCH1
   popf
@@ -179,7 +179,7 @@ asm_x64_jit_call_debug_END:
 asm_x64_jit_jump_interp:
   mov REG_6502_PC_32, 0x7fffffff
 asm_x64_jit_jump_interp_pc_patch:
-  jmp 0
+  jmp asm_x64_unpatched_branch_target
 asm_x64_jit_jump_interp_jump_patch:
 
 asm_x64_jit_jump_interp_END:
@@ -361,7 +361,7 @@ asm_x64_jit_CHECK_PENDING_IRQ:
   mov REG_SCRATCH1_32, [REG_SCRATCH1 + K_STATE_6502_OFFSET_REG_IRQ_FIRE]
   lea REG_SCRATCH1_32, [REG_SCRATCH1 - 1]
   bt REG_SCRATCH1_32, 31
-  jae 0
+  jae asm_x64_unpatched_branch_target
 asm_x64_jit_CHECK_PENDING_IRQ_jump_patch:
 
 asm_x64_jit_CHECK_PENDING_IRQ_END:
@@ -1013,7 +1013,7 @@ asm_x64_jit_ASL_ZPG_END:
 .globl asm_x64_jit_BCC
 .globl asm_x64_jit_BCC_END
 asm_x64_jit_BCC:
-  jae 0
+  jae asm_x64_unpatched_branch_target
 
 asm_x64_jit_BCC_END:
   ret
@@ -1031,7 +1031,7 @@ asm_x64_jit_BCC_8bit_END:
 .globl asm_x64_jit_BCS
 .globl asm_x64_jit_BCS_END
 asm_x64_jit_BCS:
-  jb 0
+  jb asm_x64_unpatched_branch_target
 
 asm_x64_jit_BCS_END:
   ret
@@ -1049,7 +1049,7 @@ asm_x64_jit_BCS_8bit_END:
 .globl asm_x64_jit_BEQ
 .globl asm_x64_jit_BEQ_END
 asm_x64_jit_BEQ:
-  je 0
+  je asm_x64_unpatched_branch_target
 
 asm_x64_jit_BEQ_END:
   ret
@@ -1085,7 +1085,7 @@ asm_x64_jit_BIT_ZPG_END:
 .globl asm_x64_jit_BMI
 .globl asm_x64_jit_BMI_END
 asm_x64_jit_BMI:
-  js 0
+  js asm_x64_unpatched_branch_target
 
 asm_x64_jit_BMI_END:
   ret
@@ -1103,7 +1103,7 @@ asm_x64_jit_BMI_8bit_END:
 .globl asm_x64_jit_BNE
 .globl asm_x64_jit_BNE_END
 asm_x64_jit_BNE:
-  jne 0
+  jne asm_x64_unpatched_branch_target
 
 asm_x64_jit_BNE_END:
   ret
@@ -1121,7 +1121,7 @@ asm_x64_jit_BNE_8bit_END:
 .globl asm_x64_jit_BPL
 .globl asm_x64_jit_BPL_END
 asm_x64_jit_BPL:
-  jns 0
+  jns asm_x64_unpatched_branch_target
 
 asm_x64_jit_BPL_END:
   ret
@@ -1139,7 +1139,7 @@ asm_x64_jit_BPL_8bit_END:
 .globl asm_x64_jit_BVC
 .globl asm_x64_jit_BVC_END
 asm_x64_jit_BVC:
-  jae 0
+  jae asm_x64_unpatched_branch_target
 
 asm_x64_jit_BVC_END:
   ret
@@ -1157,7 +1157,7 @@ asm_x64_jit_BVC_8bit_END:
 .globl asm_x64_jit_BVS
 .globl asm_x64_jit_BVS_END
 asm_x64_jit_BVS:
-  jb 0
+  jb asm_x64_unpatched_branch_target
 
 asm_x64_jit_BVS_END:
   ret
@@ -1489,7 +1489,7 @@ asm_x64_jit_INC_ZPG_END:
 .globl asm_x64_jit_JMP
 .globl asm_x64_jit_JMP_END
 asm_x64_jit_JMP:
-  jmp 0
+  jmp asm_x64_unpatched_branch_target
 
 asm_x64_jit_JMP_END:
   ret


### PR DESCRIPTION
(I used clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final).)

The assembler code uses "jmp 0" (etc.) in various places, to produce a
jump with a 4-byte offset. clang's assembler doesn't accept this syntax,
but you can force it to generate a 4-byte offset by jumping to an undefined
symbol. The assembler can't prove the label is close enough for a 1-byte
offset, so it generates a 4-byte one.

Then add a suitable C function, so it links. (The C function does an int 3,
so if an un-fixed-up branch is ever encountered, something obvious will
happen.)

This all seems to work just the same with gcc.