### PR TITLE
Avoid compiler warnings (since they make compilation fail).

### DIFF
--- a/bbc.c
+++ b/bbc.c
@@ -528,7 +528,7 @@ bbc_read_callback(void* p,
     } else {
       log_do_log(k_log_misc, k_log_unimplemented, "read of $FEC0-$FEDF region");
     }
-    /* fall through */
+    /* fallthrough */
   case (k_addr_tube + 0):
   case (k_addr_tube + 4):
   case (k_addr_tube + 8):

--- a/bbc.c
+++ b/bbc.c
@@ -528,6 +528,7 @@ bbc_read_callback(void* p,
     } else {
       log_do_log(k_log_misc, k_log_unimplemented, "read of $FEC0-$FEDF region");
     }
+    /* fall through */
   case (k_addr_tube + 0):
   case (k_addr_tube + 4):
   case (k_addr_tube + 8):

--- a/log.c
+++ b/log.c
@@ -77,7 +77,10 @@ log_set_do_log_to_stdout(int do_log_to_stdout) {
 static void
 log_do_log_va_list(int module, int severity, const char* p_msg, va_list args) {
   char msg[256];
-  char msg2[256];
+  char msg2[sizeof(msg)
+	    + 13 /* longest severity */
+	    + 11 /* longest module */
+	    + 3 /* separators */];
   int ret;
 
   const char* p_module_str = log_module_to_string(module);


### PR DESCRIPTION
This patch fixes compilation failure on GCC 8.3.0 (failure because -Werror).

I added a fallthrough comment to silence a warning, but before applying please check that the fallthrough was actually deliberate.

The warnings are:

```
$ ./build.sh 
bbc.c: In function ‘bbc_read_callback’:
bbc.c:521:8: error: this statement may fall through [-Werror=implicit-fallthrough=]
     if (!p_bbc->is_master) {
        ^
bbc.c:526:3: note: here
   case (k_addr_tube + 0):
   ^~~~
bbc.c: At top level:
cc1: error: unrecognized command line option ‘-Wno-address-of-packed-member’ [-Werror]
cc1: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
cc1: all warnings being treated as errors
log.c: In function ‘log_do_log_va_list’:
log.c:105:28: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 254 [-Werror=format-truncation=]
                     "%s:%s:%s\n",
                            ^~
log.c:108:21:
                     msg);
                     ~~~     
log.c:103:12: note: ‘snprintf’ output 4 or more bytes (assuming 259) into a destination of size 256
     (void) snprintf(msg2,
            ^~~~~~~~~~~~~~
                     sizeof(msg2),
                     ~~~~~~~~~~~~~
                     "%s:%s:%s\n",
                     ~~~~~~~~~~~~~
                     p_severity_str,
                     ~~~~~~~~~~~~~~~
                     p_module_str,
                     ~~~~~~~~~~~~~
                     msg);
                     ~~~~
log.c: At top level:
cc1: error: unrecognized command line option ‘-Wno-address-of-packed-member’ [-Werror]
cc1: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
cc1: all warnings being treated as errors
```
