### PR TITLE
Create 8271.rom, since we need it in the tests.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,17 +6,23 @@ set -e
 
 gcc -Wall -W -Werror -g -o make_test_rom make_test_rom.c \
     util.c defs_6502.c emit_6502.c test_helper.c
+./make_test_rom
+
 gcc -Wall -W -Werror -g -o make_timing_rom make_timing_rom.c \
     util.c defs_6502.c emit_6502.c test_helper.c
+./make_timing_rom
+
 gcc -Wall -W -Werror -g -o make_master_rom make_master_rom.c \
     util.c defs_6502.c emit_6502.c test_helper.c
+./make_master_rom
+
 gcc -Wall -W -Werror -g -o make_8271_rom make_8271_rom.c \
     util.c defs_6502.c emit_6502.c test_helper.c
+./make_8271_rom
+
 gcc -Wall -W -Werror -g -o make_perf_rom make_perf_rom.c \
     util.c defs_6502.c emit_6502.c test_helper.c
-./make_test_rom
-./make_timing_rom
-./make_master_rom
+./make_perf_rom
 
 echo 'Running built-in unit tests.'
 ./beebjit -test


### PR DESCRIPTION
At current beebjit master, build.sh doesn't create 8271.rom but it needs it.