### PR TITLE
Fixes for building on Windows

### DIFF
--- a/build_win_dbg.sh
+++ b/build_win_dbg.sh
@@ -2,8 +2,8 @@
 
 # NOTE: -gdwarf-2 needed for my version of wine to recognize the symbols.
 
-x86_64-w64-mingw32-gcc -Wall -W -Werror \
-    -g -gdwarf-2 -o beebjit.exe \
+x86_64-w64-mingw32-gcc -Wall -W -Werror -Wno-error=address-of-packed-member \
+    -D__MSVCRT_VERSION__=0x1300 -g -gdwarf-2 -o beebjit.exe \
     main.c config.c bbc.c defs_6502.c state.c video.c via.c \
     emit_6502.c interp.c inturbo.c state_6502.c sound.c timing.c \
     jit_compiler.c cpu_driver.c \

--- a/build_win_opt.sh
+++ b/build_win_opt.sh
@@ -2,8 +2,8 @@
 
 # NOTE: -gdwarf-2 needed for my version of wine to recognize the symbols.
 
-x86_64-w64-mingw32-gcc -Wall -W -Werror \
-    -O3 -DNDEBUG -o beebjit.exe \
+x86_64-w64-mingw32-gcc -Wall -W -Werror -Wno-error=address-of-packed-member \
+    -O3 -DNDEBUG -D__MSVCRT_VERSION__=0x1300 -o beebjit.exe \
     main.c config.c bbc.c defs_6502.c state.c video.c via.c \
     emit_6502.c interp.c inturbo.c state_6502.c sound.c timing.c \
     jit_compiler.c cpu_driver.c \

--- a/util.c
+++ b/util.c
@@ -262,6 +262,21 @@ util_is_extension(const char* p_file_name, const char* p_ext) {
   return 1;
 }
 
+static char *
+util_strndup(const char *s, size_t n) {
+    char *p;
+    size_t n1;
+
+    for (n1 = 0; n1 < n && s[n1] != '\0'; n1++)
+        continue;
+    p = malloc(n + 1);
+    if (p != NULL) {
+        memcpy(p, s, n1);
+        p[n1] = '\0';
+    }
+    return p;
+}
+
 void
 util_file_name_split(char** p_file_name_base,
                      char** p_file_name,
@@ -284,7 +299,7 @@ util_file_name_split(char** p_file_name_base,
   }
 
   len = (p_sep - p_full_file_name);
-  *p_file_name_base = strndup(p_full_file_name, len);
+  *p_file_name_base = util_strndup(p_full_file_name, len);
   *p_file_name = strdup(p_sep + 1);
 }
 


### PR DESCRIPTION
Fixed a few build errors when building on mingw-w64:
- strdup() is not part of the standard library and needed to be reimplemented locally
- the state save/load generates warnings with the packed struct. Struct packing is also not standard C - the struct should probably be left 'natural' and save/load to disk written so that the data is packed. I couldn't be bothered, and just turned off errors for the warning in question, so this is $TODO!
- MinGW needed a special define so that printf formatters worked without warning. This is MinGW weirdness I think.

For Win32 builds, beebjit will look in the executable directory for the roms. This means the roms can _only_ be placed there now; if we want to be able to load a rom from an arbitrary file path, we would need to do this differently, and prepend the baked in filenames for the default roms with the executable path.