### PR TITLE
fix for pulse/error

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,3 +24,5 @@ system headers (including X11 and ALSA) but nothing exotic.
 
 To get ALSA headers on Debian/Ubuntu: sudo apt install libasound2-dev
 To get ALSA headers on Fedora: sudo dnf install alsa-lib-devel
+
+To get Pulse on Debian/Ubuntu: sudo apt-get install libpulse-dev


### PR DESCRIPTION
I have some pulse/error on ubuntu/kde 
```
~/src/beebjit [master|✔] 18:23 ∴ ./build.sh
In file included from os.c:17:
os_sound_linux.c:7:10: fatal error: pulse/error.h: No such file or directory
    7 | #include <pulse/error.h>
      |          ^~~~~~~~~~~~~~~
```