### PR TITLE
Fix issue with timing of recording screen output

### DIFF
--- a/bbc.c
+++ b/bbc.c
@@ -1171,7 +1171,8 @@ bbc_framebuffer_ready_callback(void* p,
   struct bbc_message message;
 
   struct bbc_struct* p_bbc = (struct bbc_struct*) p;
-  int do_wait_for_render = !p_bbc->fast_flag;
+  int do_wait_for_render = !p_bbc->fast_flag ||
+                           video_has_paint_timer_triggered(p_bbc->p_video);
 
   message.data[0] = k_message_vsync;
   message.data[1] = do_full_render;

--- a/video.c
+++ b/video.c
@@ -2185,4 +2185,9 @@ video_get_crtc_state(struct video_struct* p_video,
   *p_is_in_dummy_raster = p_video->in_dummy_raster;
 }
 
+int
+video_has_paint_timer_triggered(struct video_struct* p_video) {
+  return p_video->has_paint_timer_triggered;
+}
+
 #include "test-video.c"

--- a/video.h
+++ b/video.h
@@ -74,4 +74,6 @@ void video_get_crtc_state(struct video_struct* p_video,
                           int* p_is_in_vert_adjust,
                           int* p_is_in_dummy_raster);
 
+int video_has_paint_timer_triggered(struct video_struct* p_video);
+
 #endif /* BEEBJIT_VIDEO_H */


### PR DESCRIPTION
This fixes a problem introduced by
1565081621bc49db857390eb04a52be815d66add.

This might not be the right fix, but at least it should help show where the problem is coming from.  It seems it's to do with recording after running in fast mode, and leads to a somewhat jerky recording that seems to cover more time than it should.

I don't have a standalone reproducer, but BBCMicrobot using a beebjit build without `beebjit-timing-fix.patch` (which is the same as this PR) applied fails its testsuite, which you can run with `npm test` (you might need to `killall node` to run it a second time as it seems to often leave its server running).