### PR TITLE
Support recording audio from a headless beebjit

### DIFF
--- a/main.c
+++ b/main.c
@@ -627,7 +627,7 @@ beebjit_main(void) {
     render_create_internal_buffer(p_render);
   }
 
-  if (!headless_flag && !util_has_option(p_opt_flags, "sound:off")) {
+  if (!util_has_option(p_opt_flags, "sound:off")) {
     int ret;
     char* p_device_name = NULL;
     uint32_t sound_sample_rate = k_sound_default_rate;

--- a/os_sound_null.c
+++ b/os_sound_null.c
@@ -2,10 +2,20 @@
 
 #include "util.h"
 
+static uint32_t k_os_sound_default_buffer_size = 2048;
+
+struct os_sound_struct {
+  struct util_file* p_output;
+  char* p_device_name;
+  uint32_t sample_rate;
+  uint32_t buffer_size;
+  uint32_t num_periods;
+  uint32_t period_size;
+};
+
 uint32_t
 os_sound_get_default_buffer_size(void) {
-  util_bail("headless");
-  return 0;
+  return k_os_sound_default_buffer_size;
 }
 
 struct os_sound_struct*
@@ -13,54 +23,59 @@ os_sound_create(char* p_device_name,
                 uint32_t sample_rate,
                 uint32_t buffer_size,
                 uint32_t num_periods) {
-  (void) p_device_name;
-  (void) sample_rate;
-  (void) buffer_size;
-  (void) num_periods;
-  util_bail("headless");
-  return NULL;
+  struct os_sound_struct* p_driver =
+      util_mallocz(sizeof(struct os_sound_struct));
+  if (p_device_name == NULL) {
+    p_driver->p_device_name = NULL;
+  } else {
+    p_driver->p_device_name = strdup(p_device_name);
+  }
+  p_driver->sample_rate = sample_rate;
+  p_driver->buffer_size = buffer_size;
+  p_driver->num_periods = num_periods;
+  p_driver->period_size = (p_driver->buffer_size / p_driver->num_periods);
+  return p_driver;
 }
 
 void
 os_sound_destroy(struct os_sound_struct* p_driver) {
-  (void) p_driver;
-  util_bail("headless");
+  if (p_driver->p_output != NULL) {
+    util_file_close(p_driver->p_output);
+    p_driver->p_output = NULL;
+  }
 }
 
 int
 os_sound_init(struct os_sound_struct* p_driver) {
-  (void) p_driver;
-  util_bail("headless");
-  return -1;
+  if (p_driver->p_device_name == NULL) {
+    return -1;
+  }
+  p_driver->p_output = util_file_try_open(p_driver->p_device_name, 1, 1);
+  if (p_driver->p_output == NULL) {
+    log_do_log(k_log_audio, k_log_error, "open failed");
+    return -1;
+  }
+  return 0;
 }
 
 uint32_t
 os_sound_get_sample_rate(struct os_sound_struct* p_driver) {
-  (void) p_driver;
-  util_bail("headless");
-  return 0;
+  return p_driver->sample_rate;
 }
 
 uint32_t
 os_sound_get_buffer_size(struct os_sound_struct* p_driver) {
-  (void) p_driver;
-  util_bail("headless");
-  return 0;
+  return p_driver->buffer_size;
 }
 
 uint32_t
 os_sound_get_period_size(struct os_sound_struct* p_driver) {
-  (void) p_driver;
-  util_bail("headless");
-  return 0;
+  return p_driver->period_size;
 }
 
 void
 os_sound_write(struct os_sound_struct* p_driver,
                int16_t* p_frames,
                uint32_t num_frames) {
-  (void) p_driver;
-  (void) p_frames;
-  (void) num_frames;
-  util_bail("headless");
+  util_file_write(p_driver->p_output, p_frames, num_frames * sizeof(int16_t));
 }


### PR DESCRIPTION
If -opt sound:dev is specified, it's taken to be a filename to save audio data too.

The format is 16 bit unsigned raw audio data, with a default sample rate of 48kHz.