### PR TITLE
Vectoreyes/xor 64 fixes

### DIFF
--- a/render.c
+++ b/render.c
@@ -236,6 +236,11 @@ render_get_buffer_size(struct render_struct* p_render) {
   return (p_render->width * p_render->height * 4);
 }
 
+int
+render_is_clock_2MHz(struct render_struct* p_render) {
+  return p_render->is_clock_2MHz;
+}
+
 uint32_t
 render_get_horiz_pos(struct render_struct* p_render) {
   return p_render->horiz_beam_pos;

--- a/render.c
+++ b/render.c
@@ -236,11 +236,6 @@ render_get_buffer_size(struct render_struct* p_render) {
   return (p_render->width * p_render->height * 4);
 }
 
-int
-render_is_clock_2MHz(struct render_struct* p_render) {
-  return p_render->is_clock_2MHz;
-}
-
 uint32_t
 render_get_horiz_pos(struct render_struct* p_render) {
   return p_render->horiz_beam_pos;

--- a/render.h
+++ b/render.h
@@ -35,9 +35,6 @@ void render_set_flyback_callback(struct render_struct* p_render,
 uint32_t render_get_width(struct render_struct* p_render);
 uint32_t render_get_height(struct render_struct* p_render);
 uint32_t render_get_buffer_size(struct render_struct* p_render);
-
-int render_is_clock_2MHz(struct render_struct* p_render);
-
 uint32_t render_get_horiz_pos(struct render_struct* p_render);
 uint32_t render_get_vert_pos(struct render_struct* p_render);
 

--- a/render.h
+++ b/render.h
@@ -36,6 +36,8 @@ uint32_t render_get_width(struct render_struct* p_render);
 uint32_t render_get_height(struct render_struct* p_render);
 uint32_t render_get_buffer_size(struct render_struct* p_render);
 
+int render_is_clock_2MHz(struct render_struct* p_render);
+
 uint32_t render_get_horiz_pos(struct render_struct* p_render);
 uint32_t render_get_vert_pos(struct render_struct* p_render);
 

--- a/video.c
+++ b/video.c
@@ -209,8 +209,12 @@ video_read_data_byte(struct video_struct* p_video,
     /* In the corner-case combination of MODE7 style addressing, plus a 2MHz
      * CRTC clock, a quirk of the memory refresh system is revealed. The
      * memory fetch address bit MA6 is xor'ed with the 1MHz clock.
+     * Testing on a BBC Master reveals that this xor of bit 6 should happen on
+     * 'even' ticks which is why the '(ticks & 1)' check is inverted.
+     * This could possibly be simplified (no need for the is_render_2MHz check)
+     * but would require substantial refactoring of the code that deals with crtc ticks.
      */
-    if (is_render_2MHz == 1 && !(ticks & 1)) {
+    if ((is_render_2MHz == 1) && !(ticks & 1)) {
       address ^= 64;
     }
   } else {

--- a/video.c
+++ b/video.c
@@ -194,7 +194,8 @@ video_read_data_byte(struct video_struct* p_video,
                      uint64_t ticks,
                      uint32_t address_counter,
                      uint8_t scanline_counter,
-                     uint32_t screen_wrap_add) {
+                     uint32_t screen_wrap_add,
+                     int is_render_2MHz) {
   uint32_t address;
 
   /* If MA13 set => MODE7 style addressing. */
@@ -209,7 +210,7 @@ video_read_data_byte(struct video_struct* p_video,
      * CRTC clock, a quirk of the memory refresh system is revealed. The
      * memory fetch address bit MA6 is xor'ed with the 1MHz clock.
      */
-    if (ticks & 1) {
+    if (is_render_2MHz == 1 && !(ticks & 1)) {
       address ^= 64;
     }
   } else {
@@ -706,7 +707,8 @@ video_advance_crtc_timing(struct video_struct* p_video) {
                                   ticks,
                                   address_counter,
                                   p_video->scanline_counter,
-                                  p_video->screen_wrap_add);
+                                  p_video->screen_wrap_add,
+                                  render_is_clock_2MHz(p_render));
       render_render(p_render, data, address_counter, ticks);
     }
 
@@ -1788,7 +1790,8 @@ video_render_full_frame(struct video_struct* p_video) {
                                     0,
                                     crtc_line_address,
                                     i_lines,
-                                    screen_wrap_add);
+                                    screen_wrap_add,
+                                    render_is_clock_2MHz(p_render));
         render_render(p_render, data, crtc_line_address, 0);
         crtc_line_address++;
       }

--- a/video.c
+++ b/video.c
@@ -209,8 +209,9 @@ video_read_data_byte(struct video_struct* p_video,
     /* In the corner-case combination of MODE7 style addressing, plus a 2MHz
      * CRTC clock, a quirk of the memory refresh system is revealed. The
      * memory fetch address bit MA6 is xor'ed with the 1MHz clock.
-     * Testing LinearTTX.ssd on a BBC Master reveals that this xor of bit 6 should
-     * happen on 'even' ticks which is why the '(ticks & 1)' check is inverted.
+     * Testing LinearTTX.ssd on a BBC Master indicates the xor of bit 6
+     * should happen on 'even' ticks, which is why the '(ticks & 1)'
+     * check is inverted.
      */
     if (!is_teletext && !(ticks & 1)) {
       address ^= 64;
@@ -639,6 +640,7 @@ video_advance_crtc_timing(struct video_struct* p_video) {
 
     if (p_video->is_rendering_active) {
       uint16_t address_counter = p_video->address_counter;
+      int is_teletext = (p_video->video_ula_control & k_ula_teletext);
 
       if (r1_hit || r0_hit) {
         p_video->display_enable_bits &= ~k_video_display_enable_horiz;
@@ -704,8 +706,6 @@ video_advance_crtc_timing(struct video_struct* p_video) {
           }
         }
       }
-
-      int is_teletext = (p_video->video_ula_control & k_ula_teletext);
 
       data = video_read_data_byte(p_video,
                                   ticks,


### PR DESCRIPTION
This fixes an issue where if the CRTC is in 2MHz mode (e.g. MODE1) but address translation is in 'TTX' mode (which would usually only be used by MODE7) and is therefore rendering from the linear area at 7C00 - 7FFF (actual address) / 2C00 - 2FFF (CRTC address) then the XOR of bit 6 happens to the wrong bytes. The practical upshot of this is you see the wrong area of memory rendered if, for instance, you set up rendering for MODE1 but then redirect the CRTC address to, say, 2C00.

This PR aims to address this issue, but it is somewhat experimental and a bit of a sticking plaster on top of other sticking plasters. It is not ideal to be checking whether the CRTC is in 2MHz mode inside the 'video_read_data_byte' function, but I couldn't see an easy way of fixing it otherwise. I tried messing around with the 'crtc ticks' adjustments that align to even vs. odd ticks, but couldn't get it working.

EDIT: Now ready for final review. We no longer have a 'is 2MHz' check inside the video_read_data_byte, instead it is an 'is_teletext' check which is appropriate and seems to match how the hardware behaves.