### PR TITLE
Mirror f3160a3b for Linux: fix intermittent mmap startup failure

### DIFF
--- a/asm/asm_platform.h
+++ b/asm/asm_platform.h
@@ -39,12 +39,17 @@
 #define K_ASM_TABLE_ADDR                   0x0          /* Unused om ARM64. */
 #endif
 #else
-/* Linux and Windows. */
-#define K_BBC_MEM_RAW_ADDR                 0x0f008000
-#define K_JIT_ADDR                         0x06000000
-#define K_INTURBO_ADDR                     0x07000000
-#define K_ASM_TABLE_ADDR                   0x50000000
-#define K_JIT_TRAMPOLINES_ADDR             0x80000000
+/* Linux and Windows. System mappings (brk heap, ASLR mmap pool) can
+ * extend a long way above the non-PIE binary at 0x400000. Mirror the
+ * macOS x64 layout: place our mappings in the 0x70000000 band where
+ * they sit well above any plausible brk growth, well below the
+ * 0x7f... high-mmap pool, and within the +-2GB disp32 jump range.
+ */
+#define K_BBC_MEM_RAW_ADDR                 0x70008000
+#define K_JIT_ADDR                         0x75000000
+#define K_INTURBO_ADDR                     0x76000000
+#define K_ASM_TABLE_ADDR                   0x77000000
+#define K_JIT_TRAMPOLINES_ADDR             0x77800000
 #endif
 
 #endif /* BEEBJIT_ASM_PLATFORM_H */

--- a/test-jit.c
+++ b/test-jit.c
@@ -1080,12 +1080,12 @@ jit_test_compile_binary(void) {
   util_buffer_destroy(p_buf);
   p_binary = jit_test_get_binary(s_p_metadata, 0x3200);
 #if defined(__x86_64__)
-  /* mov    r9b, BYTE PTR [r13+0x12017ffa]
+  /* mov    r9b, BYTE PTR [r13+0x73017ffa]
    * shr    r14b, 1
    * adc    al, 0x1
    * adc    al, BYTE PTR [rbp-0x3e]
    */
-  p_expect = "\x45\x8a\x8d\xfa\x7f\x01\x12"
+  p_expect = "\x45\x8a\x8d\xfa\x7f\x01\x73"
              "\x41\xd0\xee"
              "\x14\x01"
              "\x12\x45\xc2";
@@ -1131,13 +1131,13 @@ jit_test_compile_binary(void) {
 #if defined(__x86_64__)
   /* movzx  edx, BYTE PTR [rbp-0x10]
    * mov    dh, BYTE PTR [rbp-0x0f]
-   * xor    al, BYTE PTR [rdx+rcx*1+0x10008000]
-   * mov    BYTE PTR [rdx+rcx*1+0x11008000], al
+   * xor    al, BYTE PTR [rdx+rcx*1+0x71008000]
+   * mov    BYTE PTR [rdx+rcx*1+0x72008000], al
    */
   p_expect = "\x0f\xb6\x55\xf0"
              "\x8a\x75\xf1"
-             "\x32\x84\x0a\x00\x80\x00\x10"
-             "\x88\x84\x0a\x00\x80\x00\x11";
+             "\x32\x84\x0a\x00\x80\x00\x71"
+             "\x88\x84\x0a\x00\x80\x00\x72";
   expect_len = 21;
 #elif defined(__aarch64__)
   /* TODO: the second add y / addr check can also be eliminated. */
@@ -1244,11 +1244,11 @@ jit_test_compile_binary(void) {
 #if defined(__x86_64__)
   /* movzx  edx,BYTE PTR [rbp+0x3481]
    * mov    dh,BYTE PTR [rbp+0x3482]
-   * movzx  eax,BYTE PTR [rdx+rbx*1+0x10008000]
+   * movzx  eax,BYTE PTR [rdx+rbx*1+0x71008000]
    */
   p_expect = "\x0f\xb6\x95\x81\x34\x00\x00"
              "\x8a\xb5\x82\x34\x00\x00"
-             "\x0f\xb6\x84\x1a\x00\x80\x00\x10";
+             "\x0f\xb6\x84\x1a\x00\x80\x00\x71";
   expect_len = 21;
 #elif defined(__aarch64__)
   /* mov   x21, #0x3501
@@ -1336,7 +1336,7 @@ jit_test_compile_binary(void) {
   util_buffer_destroy(p_buf);
   p_binary = jit_test_get_binary(s_p_metadata, 0x3700);
 #if defined(__x86_64__)
-  /* mov    r9b, BYTE PTR [r13+0x12017ffa]
+  /* mov    r9b, BYTE PTR [r13+0x73017ffa]
    * sub    al, BYTE PTR [rbp-0x40]
    * sbb    al, BYTE PTR [rbp-0x3f]
    * cmc
@@ -1345,7 +1345,7 @@ jit_test_compile_binary(void) {
   /* Uses the longer-form countdown check, so fix up p_binary. */
   p_binary -= 6;
   p_binary += 11;
-  p_expect = "\x45\x8a\x8d\xfa\x7f\x01\x12"
+  p_expect = "\x45\x8a\x8d\xfa\x7f\x01\x73"
              "\x2a\x45\xc0"
              "\x1a\x45\xc1"
              "\xf5"


### PR DESCRIPTION
Hi! 

Running into the same `BAILING: mmap in wrong location` symptom as [#39](https://github.com/scarybeasts/beebjit/issues/39), this time on Linux x86-64 with ASLR. About 1% of startups on my box (~10/1000 trials on stock master `416aa90`).

Captured `heap` pointers from the failing runs land just past `K_JIT_ADDR = 0x06000000` (e.g. `heap 0x06444ea0`), so it looks like the non-PIE binary's `brk` has grown into our target band before the JIT mmap call. Same class of bug as #39, just with brk instead of libmalloc as the noisy neighbour.

Mirrored your [`f3160a3b`](https://github.com/scarybeasts/beebjit/commit/ 3160a3b5a48ae254fb8e4adcb0d8d214457ef33) fix on the Linux `#else` branch of `asm/asm_platform.h`:

```diff
 #else
 /* Linux and Windows. */
-#define K_BBC_MEM_RAW_ADDR                 0x0f008000
-#define K_JIT_ADDR                         0x06000000
-#define K_INTURBO_ADDR                     0x07000000
-#define K_ASM_TABLE_ADDR                   0x50000000
-#define K_JIT_TRAMPOLINES_ADDR             0x80000000
+#define K_BBC_MEM_RAW_ADDR                 0x70008000
+#define K_JIT_ADDR                         0x75000000
+#define K_INTURBO_ADDR                     0x76000000
+#define K_ASM_TABLE_ADDR                   0x77000000
+#define K_JIT_TRAMPOLINES_ADDR             0x77800000
 #endif
```

Re-ran the same 1000-startup loop: 1000/1000 clean. 20/20 on a real-SSD smoke (Frogger). Binary size unchanged.

Branch up on my fork at acscpt/beebjit:fix/linux-addr-band if you'd like to pull it as a PR, or happy to open one.

Thank's for beebjit