### PR TITLE
Add -log-stderr flag to log to stderr instead of stdout

### DIFF
--- a/log.c
+++ b/log.c
@@ -8,6 +8,13 @@
 #include <string.h>
 
 static int s_do_log_to_stdout = 1;
+
+//
+// Redirects the stdout log stream to stderr. No effect when
+// s_do_log_to_stdout is 0 -- that gate disables terminal logging entirely.
+//
+static int s_do_log_to_stderr = 0;
+
 static struct util_file* s_p_log_file = NULL;
 
 static const char*
@@ -74,6 +81,11 @@ log_set_do_log_to_stdout(int do_log_to_stdout) {
   s_do_log_to_stdout = do_log_to_stdout;
 }
 
+void
+log_set_log_to_stderr(void) {
+  s_do_log_to_stderr = 1;
+}
+
 static void
 log_do_log_va_list(int module, int severity, const char* p_msg, va_list args) {
   char msg[256];
@@ -92,11 +104,12 @@ log_do_log_va_list(int module, int severity, const char* p_msg, va_list args) {
   }
 
   if (s_do_log_to_stdout) {
-    ret = fprintf(stdout, "%s:%s:%s\n", p_severity_str, p_module_str, msg);
+    FILE* p_stream = s_do_log_to_stderr ? stderr : stdout;
+    ret = fprintf(p_stream, "%s:%s:%s\n", p_severity_str, p_module_str, msg);
     if (ret <= 0) {
       util_bail("fprintf failed");
     }
-    ret = fflush(stdout);
+    ret = fflush(p_stream);
     if (ret != 0) {
       util_bail("fflush failed");
     }

--- a/log.h
+++ b/log.h
@@ -29,6 +29,7 @@ enum log_severity {
 
 void log_set_log_filename(const char* p_filename);
 void log_set_do_log_to_stdout(int do_log_to_stdout);
+void log_set_log_to_stderr(void);
 
 void log_do_log(int module, int severity, const char* p_msg, ...)
     __attribute__((format(printf, 3, 4)));

--- a/main.c
+++ b/main.c
@@ -353,6 +353,8 @@ beebjit_main(void) {
       test_map_flag = 1;
     } else if (!strcmp(arg, "-no-log-stdout")) {
       log_set_do_log_to_stdout(0);
+    } else if (!strcmp(arg, "-log-stderr")) {
+      log_set_log_to_stderr();
     } else if (!strcmp(arg, "-nula")) {
       nula_flag = 1;
     } else if (!strcmp(arg, "-version") ||
@@ -380,6 +382,8 @@ beebjit_main(void) {
 "-fast              : run CPU as fast as host can; lowers accuracy.\n"
 "-accurate          : run accurately; only does anything with -fast.\n"
 "-log-file       <f>: log to file <f> as well as stdout.\n"
+"-log-stderr        : send log output to stderr rather than default stdout.\n"
+"                     Ignored if -no-log-stdout is set.\n"
 "-1770              : emulate a 1770 instead of an 8271 floppy controller.\n"
 "-master            : set up a Master 128 with MOS 3.20.\n"
 "-mos35             : set up a Master 128 with MOS 3.50.\n"


### PR DESCRIPTION
Hi there,

As promised, here's another PR for a small feature for when running beebjit headless.

Currently log output goes to stdout and mixes with emulator output. Added a `-log-stderr` flag that works alongside the
standard logging behaviour: when set, logs go to stderr instead of stdout. Makes it easier for a harness to distinguish emulator output from logging. Ignored if `-no-log-stdout` is also set.

Default behaviour is left unchanged, strictly an opt-in mechanism.

Branch up on my fork at acscpt/beebjit:pr/log-stderr.

Thanks again for beebjit!