### PR TITLE
Add headless build option for Windows

### DIFF
--- a/build_headless_win_opt.sh
+++ b/build_headless_win_opt.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# Cross-compile a headless Windows binary from Linux/MinGW.
+# Headless means no GUI/audio: stub backends from os_*_null.c.
+
+x86_64-w64-mingw32-gcc -D__USE_MINGW_ANSI_STDIO=0 \
+    -Wall -Wextra -Werror \
+    -Wpointer-arith -Wshadow \
+    -Wno-unknown-warning-option -Wno-address-of-packed-member \
+    -Wl,--disable-dynamicbase,--image-base,0x00400000 \
+    -O3 -DNDEBUG -flto -DBEEBJIT_HEADLESS -o beebjit-headless.exe \
+    main.c config.c bbc.c defs_6502.c state.c video.c via.c \
+    emit_6502.c interp.c inturbo.c state_6502.c sound.c timing.c \
+    jit_compiler.c jit_metadata.c cpu_driver.c \
+    jit_optimizer.c jit_opcode.c keyboard.c \
+    teletext.c render.c mc6850.c serial_ula.c \
+    log.c test.c adc.c cmos.c joystick.c \
+    tape.c tape_csw.c tape_uef.c \
+    intel_fdc.c wd_fdc.c \
+    disc_drive.c disc.c ibm_disc_format.c disc_tool.c \
+    disc_fsd.c disc_hfe.c disc_ssd.c disc_adl.c \
+    disc_rfi.c disc_kryo.c disc_scp.c disc_dfi.c \
+    debug.c jit.c expression.c \
+    util.c util_string.c util_container.c util_compress.c \
+    os.c \
+    asm/asm_abi.c asm/asm_tables.c asm/asm_util.c \
+    asm/asm_common.c asm/asm_common.S \
+    asm/asm_inturbo.c asm/asm_inturbo.S \
+    asm/asm_jit.c asm/asm_jit.S \
+    -lwinmm

--- a/os.c
+++ b/os.c
@@ -49,11 +49,16 @@
 #include "os_channel_windows.c"
 #include "os_fault_windows.c"
 #include "os_poller_windows.c"
-#include "os_sound_windows.c"
 #include "os_terminal_windows.c"
 #include "os_thread_windows.c"
 #include "os_time_windows.c"
+#if defined(BEEBJIT_HEADLESS)
+#include "os_sound_null.c"
+#include "os_window_null.c"
+#else
+#include "os_sound_windows.c"
 #include "os_window_windows.c"
+#endif
 
 #else
 

--- a/os_time_windows.c
+++ b/os_time_windows.c
@@ -1,5 +1,6 @@
 #include "os_time.h"
 
+#include "log.h"
 #include "util.h"
 
 #include <inttypes.h>


### PR DESCRIPTION
Hi,

Here's another small PR. This one adds a headless build option for Windows, mirroring the existing Linux/macOS headless support.

- `os.c` previously honoured `BEEBJIT_HEADLESS` only on the Linux/macOS branch. This PR extends the same guard to the Windows branch so `os_sound_windows.c` and `os_window_windows.c` are swapped for the existing `os_sound_null.c` / `os_window_null.c` stubs.
- New `build_headless_win_opt.sh` mirroring `build_win_opt.sh` with `-DBEEBJIT_HEADLESS`, dropping `-lgdi32` (no GUI), keeping `-lwinmm` (`os_time_windows.c` still uses the multimedia timer). Image base is passed via the comma-joined `-Wl,...,--image-base,0x00400000` form, which newer mingw-w64 requires.
- One small prerequisite fix: `os_time_windows.c` was relying on a transitive include of `log.h` via `os_sound_windows.c`. Dropping the latter under headless breaks that chain, so the include is made explicit. Split into its own commit since it stands alone as a latent-bug fix.

**Testing**

I built and ran this from a Linux box using the mingw-w64 cross-compiler, then exercised the resulting `beebjit-headless.exe` under Wine (6.0.3). `-help` prints the usage cleanly, so linkage and the entry path are sound. I also re-ran `build_headless_opt.sh` (Linux headless) to confirm no regression from the shared `os.c` edit.
